### PR TITLE
add pattern to select.

### DIFF
--- a/src/components/SignupForm/SignupForm.jsx
+++ b/src/components/SignupForm/SignupForm.jsx
@@ -124,6 +124,7 @@ const SignupForm = props => {
         </label>
         <input
           type="text"
+          pattern="[0-9]*"
           autoComplete="off"
           id="zip"
           value={zip}


### PR DESCRIPTION
This restricts the keyboard for mobile devices so it only opens up a numpad. Obviously we don't need letters for our zip codes.